### PR TITLE
Fix wart that scalafmt will reformt `behavior of` in scalatest

### DIFF
--- a/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
+++ b/scalafmt-core/shared/src/main/scala/org/scalafmt/config/Pattern.scala
@@ -33,6 +33,7 @@ object Pattern {
       "in",
       "ignore",
       "be",
+      "of",
       "taggedAs",
       "thrownBy",
       "synchronized",


### PR DESCRIPTION
In scalatest, scala format will reformat:
```diff
- behavior of "something"
+ behavior.of("something")
```
This patch will fix this.